### PR TITLE
Reincarnate iron-a11y-keys for PolymerElements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "iron-a11y-keys",
+  "version": "0.9.0",
+  "description": "A basic element implementation of iron-a11y-keys-behavior, matching the legacy core-a11y-keys.",
+  "keywords": [
+    "web-components",
+    "web-component",
+    "polymer",
+    "a11y",
+    "input"
+  ],
+  "authors": [
+    "The Polymer Authors"
+  ],
+  "main": "iron-a11y-keys.html",
+  "license": "MIT",
+  "dependencies": {
+    "polymer": "polymer/polymer#^0.9.0",
+    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^0.9.0"
+  },
+  "devDependencies": {
+    "iron-component-page": "polymerelements/iron-component-page#^0.9.0",
+    "test-fixture": "polymerelements/test-fixture#^0.9.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "web-component-tester": "*",
+    "iron-test-helpers": "polymerelements/iron-test-helpers#^0.9.4"
+  }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Iron A11y Keys demo</title>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="x-key-aware.html">
+</head>
+<body>
+  <x-key-aware tabindex="0"></x-key-aware>
+</body>
+</html>

--- a/demo/x-key-aware.html
+++ b/demo/x-key-aware.html
@@ -1,0 +1,77 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-a11y-keys-behavior.html">
+<link rel="import" href="../iron-a11y-keys.html">
+
+<dom-module id="x-key-aware">
+  <style>
+    :host {
+      display: block;
+      position: relative;
+    }
+  </style>
+  <template>
+    <span>Press any of these keys: <span>[[boundKeys]]</span></span>
+    <iron-a11y-keys
+      id="keys"
+      keys="* pageup pagedown left right down up shift+a alt+a home end space enter"
+      target="[[target]]"
+      on-keys-pressed="_updatePressed">
+    </iron-a11y-keys>
+    <pre id="output">[[pressed]]</pre>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'x-key-aware',
+
+    behaviors: [
+      Polymer.IronA11yKeysBehavior
+    ],
+
+    properties: {
+      pressed: {
+        type: String,
+        readOnly: true,
+        value: ''
+      },
+
+      boundKeys: {
+        type: String
+      },
+
+      target: {
+        type: Object,
+        value: function() {
+          return document.body;
+        }
+      }
+    },
+
+    keyBindings: {
+      '* pageup pagedown left right down up shift+a alt+a home end space enter': '_updatePressed'
+    },
+
+    ready: function() {
+      this.boundKeys = this.$.keys.keys;
+    },
+
+    _updatePressed: function(event) {
+      console.log(event.detail);
+
+      this._setPressed(
+        this.pressed + event.detail.combo + ' pressed!\n'
+      );
+    }
+  });
+</script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+
+  <title>iron-a11y-keys</title>
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+
+  <iron-component-page></iron-component-page>
+
+</body>
+</html>

--- a/iron-a11y-keys.html
+++ b/iron-a11y-keys.html
@@ -1,0 +1,44 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
+
+<script>
+  Polymer({
+    is: 'iron-a11y-keys',
+
+    behaviors: [
+      Polymer.IronA11yKeysBehavior
+    ],
+
+    properties: {
+      target: {
+        type: Object,
+        observer: '_targetChanged'
+      },
+
+      keys: {
+        type: String,
+        reflectToAttribute: true,
+        observer: '_keysChanged'
+      }
+    },
+
+    attached: function() {
+      if (!this.target) {
+        this.target = this.parentNode;
+      }
+    },
+
+    _targetChanged: function(target) {
+      this.keyEventTarget = target;
+    },
+
+    _keysChanged: function() {
+      this.removeOwnKeyBindings();
+      this.addOwnKeyBinding(this.keys, '_fireKeysPressed');
+    },
+
+    _fireKeysPressed: function(event) {
+      this.fire('keys-pressed', event.detail, {});
+    }
+  });
+</script>

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>iron-a11y-keys</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+
+  <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../iron-a11y-keys.html">
+</head>
+<body>
+
+  <test-fixture id="BasicKeys">
+    <template>
+      <iron-a11y-keys></iron-a11y-keys>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('<iron-a11y-keys>', function() {
+      var keys;
+
+      setup(function() {
+        keys = fixture('BasicKeys');
+      });
+
+      test('target is parentNode by default', function() {
+        expect(keys.target).to.be.equal(keys.parentNode);
+      });
+
+      suite('keys attribute', function() {
+        test('causes an event listener to be added', function(done) {
+          keys.keys = 'space';
+
+          keys.addEventListener('keys-pressed', function() {
+            done();
+          });
+
+          Polymer.Base.async(function() {
+            MockInteractions.pressSpace(keys.parentNode);
+          });
+        });
+
+        test('will not trigger events for non-specified keys', function() {
+          var keysPressedCount = 0;
+
+          keys.keys = 'space';
+
+          keys.addEventListener('keys-pressed', function() {
+            keysPressedCount++;
+          });
+
+          MockInteractions.pressSpace(keys.parentNode);
+          MockInteractions.pressEnter(keys.parentNode);
+
+          expect(keysPressedCount).to.be.equal(1);
+        });
+
+        test('triggers events for space separated keys', function() {
+          var keysPressed = '';
+
+          keys.keys = 'a b c';
+
+          keys.addEventListener('keys-pressed', function(event) {
+            keysPressed += event.detail.key;
+          });
+
+          MockInteractions.pressAndReleaseKeyOn(keys.parentNode, 65);
+          MockInteractions.pressAndReleaseKeyOn(keys.parentNode, 66);
+          MockInteractions.pressAndReleaseKeyOn(keys.parentNode, 67);
+
+          expect(keysPressed).to.be.equal('abc');
+        });
+      });
+
+      suite('event listeners', function() {
+        test('listeners are only active when element is in document', function() {
+          var keysPressedCount = 0;
+          var parent = keys.parentNode;
+
+          keys.keys = 'space';
+
+          keys.addEventListener('keys-pressed', function(event) {
+            keysPressedCount++;
+          });
+
+          MockInteractions.pressSpace(parent);
+          expect(keysPressedCount).to.be.equal(1);
+
+          keys.parentNode.removeChild(keys);
+          TestHelpers.flushAsynchronousOperations();
+
+          MockInteractions.pressSpace(parent);
+          expect(keysPressedCount).to.be.equal(1);
+
+          parent.appendChild(keys);
+          TestHelpers.flushAsynchronousOperations();
+
+          MockInteractions.pressSpace(parent);
+          expect(keysPressedCount).to.be.equal(2);
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,29 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>Tests</title>
+
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+  </head>
+
+  <body>
+    <script>
+      // Load and run all tests (.html, .js) as one suite:
+      WCT.loadSuites([
+        'basic-test.html',
+      ]);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This is intended to be a feature-compatible element to match
`core-a11y-keys` from Polymer 0.5.x land.
