### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0"
   },
   "ignore": []

--- a/demo/x-key-aware.html
+++ b/demo/x-key-aware.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../paper-styles/paper-styles.html">
+<link rel="import" href="../../paper-styles/color.html">
 <link rel="import" href="../iron-a11y-keys.html">
 
 <dom-module id="x-key-aware">
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     pre {
       color: var(--google-blue-700);
     }
-    
+
     .keys {
       line-height: 25px;
     }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -16,11 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
-
 
   <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-a11y-keys.html">
 </head>
 <body>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way
