### PR TITLE
Fixes " position in sample code.

### DIFF
--- a/iron-a11y-keys.html
+++ b/iron-a11y-keys.html
@@ -108,7 +108,7 @@ practices](http://www.w3.org/TR/wai-aria-practices/#slider):
 
     <iron-a11y-keys target="[[target]]" keys="left pagedown down" 
                     on-keys-pressed="decrement"></iron-a11y-keys>
-    <iron-a11y-keys target=""[[target]] keys="right pageup up" 
+    <iron-a11y-keys target="[[target]]" keys="right pageup up" 
                     on-keys-pressed="increment"></iron-a11y-keys>
     <iron-a11y-keys target="[[target]]" keys="home" 
                     on-keys-pressed="setMin"></iron-a11y-keys>


### PR DESCRIPTION
Just a quick fix to the documentation code in iron-a11y-keys.
