### PR TITLE
Add @export annotation to _fireKeysPressed to disable renaming by Clo…

### DIFF
--- a/iron-a11y-keys.html
+++ b/iron-a11y-keys.html
@@ -165,6 +165,7 @@ value. `setMax` should move the slider to the maximum value.
       this.addOwnKeyBinding(this.keys, '_fireKeysPressed');
     },
 
+    /** @export */
     _fireKeysPressed: function(event) {
       this.fire('keys-pressed', event.detail, {});
     }


### PR DESCRIPTION
There was an issue compiling iron-a11y-keys with Closure compiler as _fireKeysPressed gets renamed.  This fixes this issue by disabling renaming on that function.
