### PR TITLE
port to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-bower_components
-
+bower_components*
+bower-*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polylint web-component-tester
-  - bower install
-  - polylint
+  - npm install -g bower polymer-cli
+  - polymer install --variants
 env:
   global:
     - secure: >-
         R3/vUv1ZGFOaVvKRZFhNBaeGGV7U5J5aob6d9K5R7gwgyehuegVllbk1lauuhygxcNQ85+dyRXSw9+xhVa2cRtlHPbQKBMJuZt+NKsmq1+hpQ2lfyo/UWP6v7VIdjyUpKTowZj0YIohtJseW+vH9TZECfjyh+veW5B711aIQlopqswQzecvZMCigToIyx7kFujm8vTcKN4XOoNyB5FlHEnUR472XgCp4CCe/93VJixg1ccXeSR/YWDdZinHyvao4IRnrrXS2H2V7QupEQUZkcXCKAIxvuCFptpS+9ywLZpg/0YjKOazGB0eJV4p7rP1qBpnR024XA2g7mh563o+5QFZkOcPJCLohuEjBPw/XEvXtHIjlgFVtGOhPtMI6qgOz6CQzEWNEKGE083xZeMVFHxeTTVk+TT4pc4iadjwqLBZ2t7U/X4NSxnLT3olr4QL2iNesnrfE9sqbFA/8sJjZQIvaSUU0kK2xHh+W5hYfJigQvO0j9878VsGXhOTOA/OX6ghK6++qqiK39VN+rfvyLXfiO/bwUVxr8mw50ulU5prImMmxtOofD9yvEJ4TyOZoI10+k2vB+dozLvLps5oCKohJZI8xr42M3PWEFFCh/eva3DxmzsB5xdsS4TlmVccZp1SK7RC5t179RVXavzndKwqiegQC2YmblF+UtIgUn8k=
     - secure: >-
         inpQZsxZ8grQHQ8WxE3uKfZgSLzTXUp4YjBd86EXuydVQkJdMH5WWFpC0dSwb19r14b261xrwU9V1kyV6ZxXWqnb1+GORb6SVQeaKBacE85pPUXZ0kj6eSMtmQN3TMuzZZFSRzT12OEEAPQESPLbOebpydUX6IfOkF8BjeQdJ30jR5uXfOVqCobpMqsrRVJ9GGxXgF5jVdRpaqzTIl4Th1iHJUA8j48fEOhLBJKA7qzJ6xk6hAfdXQtMfDL0uwfYCI2Yd7nDZFvHPgX6bMuqui3cyKiuHxZqt/lrxYqT4L+LrRHm1I0WzcBLKBpLEAHcdhCia/GUWniuFD/va4wL3PIVbhCmEFh17IwH3aZSYfSqnIV+Cx85cjdQ4Uw5CFR46Wfu6HZ2otWpLo4uV4/7Ukq67xNzsPISOIXMOgsbnErMrdSBt28FKQxBDIAU3+Yg73h3KfXCxcYh1MQiMyu1SmVrSpHIxE1ys2LdKsPuIljagilpSgS6nOkihkrqgWJ6hxOUstDggOnG02Wgdoa4XusGz+piHyhkJQSzUkbbsGcTwKCWjrp0mIVU3fR3KLwdRzeMStMX2x6GAIBxATz7yUK2DyyoaNEWBXHg7MRZCaXcB063EJA8Qc8Sx3udubJcvXnuIXuiYm4PWw8bZTh1fYvw3ZELFuM8UbNBpvTbr9E=
-node_js: '6'
+node_js: stable
 addons:
   firefox: latest
   apt:
@@ -19,6 +18,6 @@ addons:
     packages:
       - google-chrome-stable
 script:
-  - xvfb-run wct
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'
+  - xvfb-run polymer test
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s ''default''; fi'
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -1,23 +1,8 @@
-
-<!---
-
-This README is automatically generated from the comments in these files:
-iron-a11y-keys.html
-
-Edit those files, and our readme bot will duplicate them over here!
-Edit this file, and the bot will squash your changes :)
-
-The bot does some handling of markdown. Please file a bug if it does the wrong
-thing! https://github.com/PolymerLabs/tedium/issues
-
--->
-
 [![Build status](https://travis-ci.org/PolymerElements/iron-a11y-keys.svg?branch=master)](https://travis-ci.org/PolymerElements/iron-a11y-keys)
 
 _[Demo and API docs](https://elements.polymer-project.org/elements/iron-a11y-keys)_
 
-
-##&lt;iron-a11y-keys&gt;
+## &lt;iron-a11y-keys&gt;
 
 `iron-a11y-keys` provides a cross-browser interface for processing
 keyboard commands. The interface adheres to [WAI-ARIA best
@@ -56,11 +41,11 @@ properties: {
     notify: true,
   },
   target: {
-    type: Object,
-    value: function() {
-      return this.$.input;
-    }
+    type: Object
   },
+},
+ready: function() {
+  this.target = this.$.input;
 },
 onEnter: function() {
   console.log(this.userInput);
@@ -137,5 +122,3 @@ to methods. The `increment` method should move the slider a set amount
 toward the maximum value. `decrement` should move the slider a set amount
 toward the minimum value. `setMin` should move the slider to the minimum
 value. `setMax` should move the slider to the maximum value.
-
-

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-a11y-keys",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "A basic element implementation of iron-a11y-keys-behavior, matching the legacy core-a11y-keys.",
   "keywords": [
     "web-components",
@@ -19,16 +19,30 @@
   "main": "iron-a11y-keys.html",
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0",
-    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
+    "polymer": "Polymer/polymer#^2",
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#2.0-preview"
   },
   "devDependencies": {
-    "paper-styles": "PolymerElements/paper-styles#^1.0.2",
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "^4.0.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0"
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.1.0",
+        "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "web-component-tester": "^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
   },
   "ignore": []
 }

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "main": "iron-a11y-keys.html",
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
-    "polymer": "Polymer/polymer#^2",
+    "polymer": "Polymer/polymer#^2.0.0-rc.7",
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#2.0-preview"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "variants": {
     "1.x": {

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,16 +9,28 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>Iron A11y Keys demo</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+
   <link rel="import" href="x-key-aware.html">
-  <link rel="import" href="../../paper-styles/demo-pages.html">
+
+  <custom-style>
+    <style is="custom-style" include="demo-pages-shared-styles"></style>
+  </custom-style>
 </head>
-<body>
-  <div class="vertical-section vertical-section-container centered">
-    <x-key-aware tabindex="0"></x-key-aware>
-  </div>
+
+<body unresolved class="centered">
+  <demo-snippet>
+    <template>
+      <x-key-aware tabindex="0"></x-key-aware>
+    </template>
+  </demo-snippet>
 </body>
+
 </html>

--- a/demo/x-key-aware.html
+++ b/demo/x-key-aware.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../paper-styles/color.html">
 <link rel="import" href="../iron-a11y-keys.html">
 
 <dom-module id="x-key-aware">
@@ -21,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       pre {
-        color: var(--google-blue-700);
+        color: #3367d6;
       }
 
       .keys {
@@ -30,8 +29,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       .keys span {
         cursor: default;
-        background-color: var(--google-grey-100);
-        border: 1px solid var(--google-grey-300);
+        background-color: #f5f5f5;
+        border: 1px solid #e0e0e0;
         padding: 1px 5px;
         border-radius: 5px;
       }

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>Tests</title>
 
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
   </head>
 
@@ -19,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       // Load and run all tests (.html, .js) as one suite:
       WCT.loadSuites([
-        'basic-test.html',
+        'basic-test.html?wc-shadydom=true&wc-ce=true',
         'basic-test.html?dom=shadow'
       ]);
     </script>


### PR DESCRIPTION
Minimal work to port from 1.0 to 2.0.
Updated demo page to use `demo-snippet` and drop `paper-styles` dependency.
