### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-a11y-keys.js
+++ b/iron-a11y-keys.js
@@ -133,6 +133,7 @@ value. `setMax` should move the slider to the maximum value.
 
 Polymer({
   is: 'iron-a11y-keys',
+  _template: null,
 
   behaviors: [IronA11yKeysBehavior],
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336